### PR TITLE
Transition lsp-zero to v3.x

### DIFF
--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -4,10 +4,7 @@ local luasnip = require('luasnip')
 
 lsp.preset('recommended')
 
-lsp.ensure_installed({
-    'rust_analyzer', 'pyright'
-})
-
+lsp.setup_servers({'tsserver', 'rust_analyzer', 'pyright'})
 
 local cmp_select = { behavior = cmp.SelectBehavior.Replace }
 local cmp_mappings = lsp.defaults.cmp_mappings({
@@ -33,7 +30,7 @@ local cmp_mappings = lsp.defaults.cmp_mappings({
     end, { 'i', 's' })
 })
 
-lsp.setup_nvim_cmp({
+lsp.setup({
     -- Don't select the first option in the menu
     -- https://stackoverflow.com/questions/74688630/make-nvim-cmp-not-autoselect-the-1st-option
     preselect = 'none',

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -4,7 +4,7 @@ local luasnip = require('luasnip')
 
 lsp.preset('recommended')
 
-lsp.setup_servers({'tsserver', 'rust_analyzer', 'pyright'})
+lsp.setup_servers({'rust_analyzer', 'pyright'})
 
 local cmp_select = { behavior = cmp.SelectBehavior.Replace }
 local cmp_mappings = lsp.defaults.cmp_mappings({


### PR DESCRIPTION
Nice config, there are some changes I did to make it working with the updated lsp. Hope it helps

- lsp-zero to v3.x (https://github.com/VonHeikemen/lsp-zero.nvim/discussions/286) doesnt use `.ensure_installed()` and `.setup_nvim_cmp()`