### PR TITLE
Change language 'help' to updated 'vimdoc'

### DIFF
--- a/after/plugin/treesitter.lua
+++ b/after/plugin/treesitter.lua
@@ -1,6 +1,6 @@
 require'nvim-treesitter.configs'.setup {
   -- A list of parser names, or "all"
-  ensure_installed = { "help", "javascript", "python", "c", "lua", "rust", "markdown", "markdown_inline", },
+  ensure_installed = { "vimdoc", "javascript", "python", "c", "lua", "rust", "markdown", "markdown_inline", },
 
   -- Install parsers synchronously (only applied to `ensure_installed`)
   sync_install = false,


### PR DESCRIPTION
```
Installation not possible: ...vim/lazy/nvim-treesitter/lua/nvim-treesitter/install.lua:86: Parser not available for language "help"
```

"help" changed to "vimdoc".

